### PR TITLE
Subapps are not mounted

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,6 +95,22 @@ function wrap(handler, verb) {
 // TODO: This only patches HTTP servers in Express 2, not HTTPS ones.
 var proto = express.application || express.HTTPServer.prototype;
 
+// Checks whether fn is a request handler. Note that Express apps are excluded to avoid patching them below.
+// For more information see https://github.com/aseemk/express-streamline/pull/16.
+function isRequestHandler(fn) {
+    if (typeof fn !== 'function') {
+        return false;
+    }
+
+    // check if fn is an Express app
+    // condition taken from here: https://github.com/strongloop/express/blob/4.11.2/lib/application.js#L186
+    if (fn.handle && fn.set) {
+        return false;
+    }
+
+    return true;
+}
+
 //
 // Helper function to patch proto[verb], to wrap passed-in Streamline-style
 // handlers (req, res, _) to the style Express needs (req, res, next).
@@ -113,7 +129,7 @@ function patch(verb) {
         var lastArg = arguments[last];
 
         // if there is one, wrap it:
-        if (typeof lastArg === 'function') {
+        if (isRequestHandler(lastArg)) {
             arguments[last] = wrap(lastArg, verb);
         }
 

--- a/test.js
+++ b/test.js
@@ -4,6 +4,14 @@ var req = require('supertest');
 
 exports['express-streamline'] = {
 
+    'should properly mount subapps': function () {
+        var express = require('./');
+        var app = express();
+        var subapp = express();
+        app.use('/subapp', subapp);
+        assert.equal(subapp.parent, app);
+    },
+
     'should properly handle async routes and middleware': function (next) {
         req(app)
             .get('/')


### PR DESCRIPTION
When I access [`req.app.mountpath`][mountpath] in the [Router][router] of a subapp, the behavior is different than from without streamline.

[Without express-streamline](https://github.com/winniehell/express-sandbox/tree/without-streamline) I get
```
$ npm test
> curl localhost:3456/subapp/
/subapp
/subapp
```
but [with streamline](https://github.com/winniehell/express-sandbox/tree/with-streamline) I get
```
$ npm test
> curl localhost:3456/subapp/
/
/subapp
```

[mountpath]: http://expressjs.com/4x/api.html#app.mountpath
[router]: http://expressjs.com/4x/api.html#router

Edit by @aseemk: [diff between branches](https://github.com/winniehell/express-sandbox/compare/without-streamline...with-streamline)