### PR TITLE
Support Express 4 Routers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,8 @@ language: node_js
 node_js:
   - "0.12"
   - "0.10"
-  - "0.8"
 env:
   - EXPRESS_VERSION='>= 5.0.0-alpha.1'
   - EXPRESS_VERSION=4
-  - EXPRESS_VERSION=3
 before_script:
   - npm install express@"$EXPRESS_VERSION"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Patch for [Express](http://expressjs.com/) to add support for
 [Streamline](https://github.com/Sage/streamlinejs) syntax in Express apps.
 
-Supports Express 2 through 5.
+Supports Express 4 and 5.
 
 ## Example
 

--- a/example._js
+++ b/example._js
@@ -25,6 +25,7 @@ var crypto = require('crypto');
 var express = require('./');
 var logger = require('morgan');
 var responseTime = require('response-time');
+var router = express.Router();
 var streamlineGlobal = require('streamline/lib/globals');
 
 var app = express();
@@ -130,6 +131,26 @@ app.use(function (err, req, res, _) {
     setTimeout(_, 1);
     res.status(500).send(err.message);
 });
+
+// there is no Router for Express 3
+if (router) {
+    // Router example (normal):
+    router.get('/router', function (req, res, _) {
+        // wait if we fall through
+        process.nextTick(function () {
+            res.send(res.locals.message);
+        });
+
+        res.locals.message = 'Hello from Router!';
+    });
+
+    // Router example (fall-through check):
+    router.get('/router', function (req, res, _) {
+        res.locals.message = 'Router is falling through...';
+    });
+
+    app.use('/', router);
+}
 
 module.exports = app;
 

--- a/example._js
+++ b/example._js
@@ -132,21 +132,18 @@ app.use(function (err, req, res, _) {
     res.status(500).send(err.message);
 });
 
-// there is no Router for Express 3
-if (router) {
-    // Router example (normal):
-    router.get('/router', function (req, res, _) {
-        res.send('Hello from Router!');
-    });
+// Router example (normal):
+router.get('/router', function (req, res, _) {
+    res.send('Hello from Router!');
+});
 
-    // Router example (fall-through check):
-    router.get('/router', function (req, res, _) {
-        throw new Error('not');
-        app.locals.router_falling_through = true;
-    });
+// Router example (fall-through check):
+router.get('/router', function (req, res, _) {
+    throw new Error('not');
+    app.locals.router_falling_through = true;
+});
 
-    app.use('/', router);
-}
+app.use('/', router);
 
 module.exports = app;
 

--- a/example._js
+++ b/example._js
@@ -136,17 +136,13 @@ app.use(function (err, req, res, _) {
 if (router) {
     // Router example (normal):
     router.get('/router', function (req, res, _) {
-        // wait if we fall through
-        process.nextTick(function () {
-            res.send(res.locals.message);
-        });
-
-        res.locals.message = 'Hello from Router!';
+        res.send('Hello from Router!');
     });
 
     // Router example (fall-through check):
     router.get('/router', function (req, res, _) {
-        res.locals.message = 'Router is falling through...';
+        throw new Error('not');
+        app.locals.router_falling_through = true;
     });
 
     app.use('/', router);

--- a/index.js
+++ b/index.js
@@ -9,147 +9,44 @@ try {
     streamlineGlobal = require('streamline/lib/globals');
 } catch (err) {}
 
-//
-// Helper function to wrap the given Streamline-style handler (req, res, _)
-// to the style Express requires (req, res, next).
-//
-// Returns the wrapped (req, res, next) handler for Express.
-//
-// Supports other types of handlers too, e.g. with different signatures, via
-// the `verb` param. Non-route verbs include `use` and `param`.
-//
-// Middleware handlers (`use`) have the same signature as route handlers, but
-// unlike route handlers, `next()` is called by default.
-//
-// Param handlers also call `next()` by default, but their signature is
-// (req, res, _, param, key).
-//
-// Both route handlers and middleware handlers can be error handlers, with
-// the signature (err, req, res, _). This is detected by the handler arity.
-//
-// (Express 2 had an explicit `error` verb. That works too.)
-//
-// All handlers can override the default next() behavior by explicitly
-// returning true to call next() or false to not call next().
-//
-function wrap(handler, verb) {
-    var isErrorHandler = (verb === 'error') ||
-        (verb !== 'param' && handler.length >= 4);
+var Layer = require('express/lib/router/layer');
+Layer.prototype.handle_request = function handle(req, res, next) {
+    var fn = this.handle;
 
-    // unify express 2 and 3 to imaginary 'error' verb:
-    if (isErrorHandler) {
-        verb = 'error';
+    if (fn.length > 3) {
+        // not a standard request handler
+        return next();
     }
 
-    var maxArgs = verb === 'param' ? 5 : 4;
-    if (handler.length > maxArgs) {
-        var handlerStr = handler.toString().replace(/(^|\n)/g, '$1| ');
-        console.warn(
-            'Warning: Express app.%s() handler registered with >%d args. ' +
-            'Express-streamline doesn’t know how to handle these; ' +
-            'truncating to %d args.\n\n%s\n',
-            verb, maxArgs, maxArgs, handlerStr
-        );
-    }
+    try {
+        function callback(next) {
+            return function (err) {
+                if (err) return next(err);
 
-    function callback(next) {
-        return function (err, result) {
-            if (err) return next(err);
-
-            var callNext = null;
-
-            // handlers can explicitly return true or false to specify:
-            if (typeof result === 'boolean') {
-                callNext = result;
+                if (err === null) {
+                    next();
+                }
             }
-
-            // otherwise, the default is true for middleware and param
-            // handlers, false for route and error handlers:
-            if (typeof callNext !== 'boolean') {
-                callNext = (verb === 'use') || (verb === 'param');
-            }
-
-            if (callNext) {
-                return next();
-            }
-        };
-    }
-
-    switch (verb) {
-        case 'param':
-            return function (req, res, next, param, key) {
-                return handler.call(this, req, res, callback(next), param, key);
-            }
-        case 'error':
-            return function (err, req, res, next) {
-                return handler.call(this, err, req, res, callback(next));
-            }
-        default:
-            return function (req, res, next) {
-                return handler.call(this, req, res, callback(next));
-            }
-    }
-}
-
-// Express's prototype, with back-compat for Express 2.
-// TODO: This only patches HTTP servers in Express 2, not HTTPS ones.
-var proto = express.application || express.HTTPServer.prototype;
-
-// Checks whether fn is a request handler. Note that Express apps are excluded to avoid patching them below.
-// For more information see https://github.com/aseemk/express-streamline/pull/16.
-function isRequestHandler(fn) {
-    if (typeof fn !== 'function') {
-        return false;
-    }
-
-    // check if fn is an Express app
-    // condition taken from here: https://github.com/strongloop/express/blob/4.11.2/lib/application.js#L186
-    if (fn.handle && fn.set) {
-        return false;
-    }
-
-    return true;
-}
-
-//
-// Helper function to patch proto[verb], to wrap passed-in Streamline-style
-// handlers (req, res, _) to the style Express needs (req, res, next).
-//
-function patch(verb) {
-    var origProtoVerb = proto[verb];
-
-    // minor: don't patch verbs that aren't implemented by Express:
-    if (typeof origProtoVerb !== 'function') {
-        return;
-    }
-
-    proto[verb] = function () {
-        // if a handler function is given, it'll be the last argument:
-        var last = arguments.length - 1;
-        var lastArg = arguments[last];
-
-        // if there is one, wrap it:
-        if (isRequestHandler(lastArg)) {
-            arguments[last] = wrap(lastArg, verb);
         }
 
-        // finally, call the original method now with the updated args:
-        return origProtoVerb.apply(this, arguments);
-    };
-}
+        if(this.route) {
+            fn(req, res, callback(next));
+        }
+        else {
+            fn(req, res, next);
+        }
 
-// Patch all proto methods, e.g. proto.get(), proto.post(), etc.
-// Important: we don't patch `all`, as that's just a simple wrapper.
-require('methods').concat('del', 'error', 'use', 'param')
-    .forEach(function (verb) {
-        patch(verb);
-    });
+    } catch (err) {
+        next(err);
+    }
+};
 
 // Patch app.handle() to reset Streamline's global context at the beginning of
 // every request. This method is only present in Connect's prototype, *not*
 // Express's, so we patch proto.init(), which is called on app creation.
 // https://github.com/strongloop/express/blob/3.15.2/lib/express.js#L39
 if (streamlineGlobal) {
+    var proto = express.application;
     var origProtoInit = proto.init;
 
     proto.init = function () {

--- a/test.js
+++ b/test.js
@@ -98,6 +98,21 @@ exports['express-streamline'] = {
             .expect(200)
             .expect({})
             .end(next)
+    },
+
+    'should support Routers': function (next) {
+        var expressVersion = require('express/package.json').version;
+
+        if (expressVersion.match(/^3./)) {
+            console.log('Skipping this test for Express ' + expressVersion);
+            next();
+        }
+
+        req(app)
+            .get('/router')
+            .expect(200)
+            .expect('Hello from Router!')
+            .end(next)
     }
 
 };

--- a/test.js
+++ b/test.js
@@ -101,13 +101,6 @@ exports['express-streamline'] = {
     },
 
     'should support Routers': function (next) {
-        var expressVersion = require('express/package.json').version;
-
-        if (expressVersion.match(/^3./)) {
-            console.log('Skipping this test for Express ' + expressVersion);
-            next();
-        }
-
         req(app)
             .get('/router')
             .expect(200)

--- a/test.js
+++ b/test.js
@@ -112,7 +112,10 @@ exports['express-streamline'] = {
             .get('/router')
             .expect(200)
             .expect('Hello from Router!')
-            .end(next)
+            .end(function() {
+                assert(!app.locals.router_falling_through);
+                next();
+            })
     }
 
 };


### PR DESCRIPTION
For [Routers](http://expressjs.com/4x/api.html#router) the request handlers fall through. Please see the attached failing test. I think the problem is that Routers need to be patched along with apps.

The test checks whether Router is falling through. Since Routers don't exist in Express 3 the test is skipped. For Express 5 `process.nextTick` seems to run after the error handler. If you know of any other way please let me know...
