### PR TITLE
Change behavior for handlers with too many arguments

### DIFF
--- a/example._js
+++ b/example._js
@@ -125,6 +125,11 @@ app.patch('/resource', function (req, res, _) {
     res.send('Resource patched.');
 });
 
+// Example of using more arguments than usual
+app.get('/tooMany', function (req, res, _, too, many, args) {
+    res.send('arguments: ' + arguments.length);
+});
+
 // Example of error handler:
 app.use(function (err, req, res, _) {
     setTimeout(_, 1);

--- a/index.js
+++ b/index.js
@@ -34,14 +34,21 @@ try {
 //
 function wrap(handler, verb) {
     var isErrorHandler = (verb === 'error') ||
-        (verb !== 'param' && handler.length >= 4);
+        (verb !== 'param' && handler.length === 4);
 
     // unify express 2 and 3 to imaginary 'error' verb:
     if (isErrorHandler) {
         verb = 'error';
     }
 
-    var maxArgs = verb === 'param' ? 5 : 4;
+    var maxArgs;
+
+    if ((verb === 'param') || (verb === 'error')) {
+        maxArgs = 4;
+    } else {
+        maxArgs = 3;
+    }
+
     if (handler.length > maxArgs) {
         var handlerStr = handler.toString().replace(/(^|\n)/g, '$1| ');
         console.warn(

--- a/test.js
+++ b/test.js
@@ -98,6 +98,14 @@ exports['express-streamline'] = {
             .expect(200)
             .expect({})
             .end(next)
+    },
+
+    'should warn about (but ignore) additional arguments': function (next) {
+        req(app)
+          .get('/tooMany')
+          .expect(200)
+          .expect('arguments: 3')
+          .end(next)
     }
 
 };


### PR DESCRIPTION
In my opinion it is a bit surprising that

```
app.get('/tooMany', function (req, res, _, too, many, args) {
```

(see `example._js`) turns into an error handler. I would assume that it handles `GET`requests even if it has too many arguments.

Additionally it seems to me that the check for the maximum number of arguments is off by one (see [comment](https://github.com/aseemk/express-streamline/commit/960d1f95455846a4da1d95db6d9b2f266c6f3b88#commitcomment-10970907) at 960d1f95455846a4da1d95db6d9b2f266c6f3b88).
