### PR TITLE
Remove wildcard express version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,6 @@
     "streamline": "0.10.x",
     "supertest": "0.15.x"
   },
-  "peerDependencies": {
-    "express": "*"
-  },
   "engines": {
     "node": "*"
   },


### PR DESCRIPTION
Travis CI build currently fails because of npm/npm#9461. This patch removes the wildcard peer dependency as I don't know any easy way to work around this.
